### PR TITLE
Drive train/#83 calibrate encoders

### DIFF
--- a/src/main/java/org/frc5687/steamworks/protobot/Robot.java
+++ b/src/main/java/org/frc5687/steamworks/protobot/Robot.java
@@ -126,7 +126,7 @@ public class Robot extends IterativeRobot {
 
     @Override
     public void autonomousInit() {
-        autoCommand = new AutoDrive(36, -0.2);
+        autoCommand = new AutoDrive(36, -0.1);
         if (autoCommand!=null) {
             autoCommand.start();
         }

--- a/src/main/java/org/frc5687/steamworks/protobot/Robot.java
+++ b/src/main/java/org/frc5687/steamworks/protobot/Robot.java
@@ -7,11 +7,7 @@ import edu.wpi.first.wpilibj.command.Command;
 import edu.wpi.first.wpilibj.command.Scheduler;
 import edu.wpi.first.wpilibj.smartdashboard.SendableChooser;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
-import org.frc5687.steamworks.protobot.commands.DisableRingLight;
-import org.frc5687.steamworks.protobot.commands.actions.AutoAlign;
 import org.frc5687.steamworks.protobot.commands.actions.AutoDrive;
-import org.frc5687.steamworks.protobot.commands.autonomous.AutoCrossBaseline;
-import org.frc5687.steamworks.protobot.commands.autonomous.AutoDepositGear;
 import org.frc5687.steamworks.protobot.commands.autonomous.FlashLights;
 import org.frc5687.steamworks.protobot.subsystems.*;
 import org.frc5687.steamworks.protobot.utils.AutoChooser;
@@ -126,7 +122,7 @@ public class Robot extends IterativeRobot {
 
     @Override
     public void autonomousInit() {
-        autoCommand = new AutoDrive(36, -0.1);
+        autoCommand = new FlashLights();
         if (autoCommand!=null) {
             autoCommand.start();
         }

--- a/src/main/java/org/frc5687/steamworks/protobot/Robot.java
+++ b/src/main/java/org/frc5687/steamworks/protobot/Robot.java
@@ -9,6 +9,7 @@ import edu.wpi.first.wpilibj.smartdashboard.SendableChooser;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import org.frc5687.steamworks.protobot.commands.DisableRingLight;
 import org.frc5687.steamworks.protobot.commands.actions.AutoAlign;
+import org.frc5687.steamworks.protobot.commands.actions.AutoDrive;
 import org.frc5687.steamworks.protobot.commands.autonomous.AutoCrossBaseline;
 import org.frc5687.steamworks.protobot.commands.autonomous.AutoDepositGear;
 import org.frc5687.steamworks.protobot.commands.autonomous.FlashLights;
@@ -125,7 +126,7 @@ public class Robot extends IterativeRobot {
 
     @Override
     public void autonomousInit() {
-        autoCommand = new FlashLights();
+        autoCommand = new AutoDrive(36, -0.2);
         if (autoCommand!=null) {
             autoCommand.start();
         }

--- a/src/main/java/org/frc5687/steamworks/protobot/commands/actions/AutoDrive.java
+++ b/src/main/java/org/frc5687/steamworks/protobot/commands/actions/AutoDrive.java
@@ -28,6 +28,7 @@ public class AutoDrive extends Command implements PIDOutput {
 
     @Override
     protected void initialize() {
+        driveTrain.resetDriveEncoders();
         this.finalDistance = distance + driveTrain.getDistance();
         controller = new PIDController(Drive.kP, Drive.kI, Drive.kD, imu, this);
         controller.setInputRange(Constants.Auto.MAX_IMU_ANGLE, Constants.Auto.MAX_IMU_ANGLE);
@@ -51,6 +52,8 @@ public class AutoDrive extends Command implements PIDOutput {
     protected void end() {
         controller.disable();
         driveTrain.tankDrive(0,0);
+        DriverStation.reportError("Left Encoder Ticks: " + driveTrain.getLeftTicks() + "; Right Encoder Ticks: " + driveTrain.getRightTicks(), false);
+        DriverStation.reportError("Left Encoder Distance: " + driveTrain.getLeftDistance() + "; Right Encoder Distance: " + driveTrain.getRightDistance(), false);
     }
 
     @Override

--- a/src/main/java/org/frc5687/steamworks/protobot/commands/actions/AutoDrive.java
+++ b/src/main/java/org/frc5687/steamworks/protobot/commands/actions/AutoDrive.java
@@ -52,8 +52,6 @@ public class AutoDrive extends Command implements PIDOutput {
     protected void end() {
         controller.disable();
         driveTrain.tankDrive(0,0);
-        DriverStation.reportError("Left Encoder Ticks: " + driveTrain.getLeftTicks() + "; Right Encoder Ticks: " + driveTrain.getRightTicks(), false);
-        DriverStation.reportError("Left Encoder Distance: " + driveTrain.getLeftDistance() + "; Right Encoder Distance: " + driveTrain.getRightDistance(), false);
     }
 
     @Override

--- a/src/main/java/org/frc5687/steamworks/protobot/commands/actions/AutoDrive.java
+++ b/src/main/java/org/frc5687/steamworks/protobot/commands/actions/AutoDrive.java
@@ -28,7 +28,7 @@ public class AutoDrive extends Command implements PIDOutput {
 
     @Override
     protected void initialize() {
-        this.finalDistance = distance + driveTrain.getRightDistance();
+        this.finalDistance = distance + driveTrain.getDistance();
         controller = new PIDController(Drive.kP, Drive.kI, Drive.kD, imu, this);
         controller.setInputRange(Constants.Auto.MAX_IMU_ANGLE, Constants.Auto.MAX_IMU_ANGLE);
         controller.setOutputRange(-Drive.MAX_OUTPUT, Drive.MAX_OUTPUT);
@@ -43,8 +43,8 @@ public class AutoDrive extends Command implements PIDOutput {
     protected boolean isFinished() {
 
         return distance >=0
-                ? driveTrain.getRightDistance() > finalDistance
-                : driveTrain.getRightDistance() < finalDistance;
+                ? driveTrain.getDistance() > finalDistance
+                : driveTrain.getDistance() < finalDistance;
     }
 
     @Override


### PR DESCRIPTION
fixed #83 
Encoders are fine as is, but this uses DriveTrain.getDistance() where we were using DriveTrain.getRightDistance()